### PR TITLE
fix: ensure the output index file in `dist` is `index.html`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
+import fs from "node:fs/promises";
 import { defineConfig } from 'vite'
 import { vitePlugin as apimockPlugin } from "@forsakringskassan/apimock-express";
 import vue from '@vitejs/plugin-vue'
-import { resolve } from 'path'
 
 export default defineConfig(({ command }) => {
   const base = command === 'serve' ? '/' : '/designsystem-user-app/'
@@ -17,11 +17,15 @@ export default defineConfig(({ command }) => {
       apimockPlugin([
         { url: "/api/template", dir: "node_modules/@forsakringskassan/template-api/dist/mock/api/template/" },
       ]),
+      {
+        name: "fk:hack-do-not-do-this",
+        transformIndexHtml: {
+          enforce: "pre",
+          async handler() {
+            return await fs.readFile(htmlFile, "utf8");
+          },
+        },
+      },
     ],
-    build: {
-      rollupOptions: {
-        input: resolve(__dirname, htmlFile)
-      }
-    }
   }
 })


### PR DESCRIPTION
Tycker egentligen inget av det där ska med i detta exemplet, syftet med detta repot var något helt annat och nu innehåller det mönster, kod och deploymen vi inte är intresserade av. Men det får bli en senare diskussion.

I a9d858c gick deployment till github pages sönder eftersom `dist` katalogen får fel innehåll:

```
dist
├── assets
│   ├── index-CX7fqvSj.css
│   └── index.prod-Bza3rAzd.js
└── index.prod.html
```

Efter denna ändringen så blir filnamnet `index.html` igen:

```
dist
├── assets
│   ├── index-CX7fqvSj.css
│   └── index-mKhHkIXy.js
└── index.html
```

Det är mycket möjligt att docker image går sönder nu i stället men den använder inte designsystemet och det är inget mönster vi avser visa i detta exempelrepot samt att vi har ingen möjlighet att testa (det är odokumenterat, ser ingen `Dockerfile` eller liknande) så tycker jag inte vi ska ta hänsyn till att det säkert går sönder.
